### PR TITLE
Use the path module 

### DIFF
--- a/lib/venues.js
+++ b/lib/venues.js
@@ -5,7 +5,8 @@
  */
 module.exports = function(config) {
   var core = require("./core")(config),
-    logger = require('log4js')(config.log4js).getLogger("node-foursquare.Venues");
+    logger = require('log4js')(config.log4js).getLogger("node-foursquare.Venues"),
+      path = require('path');
 
   /**
    * Retrieve a list of Venue Categories.
@@ -113,7 +114,7 @@ module.exports = function(config) {
       return;
     }
 
-    core.callApi("/venues/" + venueId, accessToken, "venue", null, callback);
+    core.callApi(path.join("/venues", venueId), accessToken, "venue", null, callback);
   }
 
   /**
@@ -143,7 +144,7 @@ module.exports = function(config) {
       return;
     }
 
-    core.callApi("/venues/" + venueId + '/' + aspect, accessToken, aspect, params || {}, callback);
+    core.callApi(path.join("/venues", venueId,  aspect), accessToken, aspect, params || {}, callback);
   }
 
   /**
@@ -165,7 +166,7 @@ module.exports = function(config) {
       return;
     }
 
-    core.callApi("/venues/" + venueId + '/' + "herenow", accessToken, "hereNow", params || {}, callback);
+    core.callApi(path.join("/venues", venueId,  "herenow"), accessToken, "hereNow", params || {}, callback);
   }
 
   /**


### PR DESCRIPTION
Instead of manually constructing paths such as this:

```
"/venues" + "/" + venueId
```

Use the native nodejs path module. Calling path.join is the equivalent as above and cleans up the code

```
path.join("/venues", venueId)
```

I've only made the change to this one file, you can probably take advantage of this throughout your codebase.
http://nodejs.org/docs/v0.4.8/api/path.html#path.join
