### PR TITLE
Validation corrections

### DIFF
--- a/lib/venues.js
+++ b/lib/venues.js
@@ -72,18 +72,21 @@ module.exports = function(config) {
     logger.enter('search');
     params = params || {};
 
-    if(!lat || !lng) {
-      if(!near) {
-        if (!params.ne || !params.sw) {
-            logger.error('Either lat and lng, near, or ne/sw are required as parameters.');
-            callback(new Error('Venues.explore: near or ne/sw must be specified if lat and lng are not set.'));
-            return;
+    // Global search intent ignores all parameters other than 'query' and 'limit' so no need to validate anything.
+    if (params.intent !== 'global') {
+      if (!lat || !lng) {
+        if (!near) {
+          if (!params.ne || !params.sw) {
+              logger.error('Either lat and lng, near, or ne/sw are required as parameters.');
+              callback(new Error('Venues.explore: near or ne/sw must be specified if lat and lng are not set.'));
+              return;
+          }
+        } else {
+          params.near = near;
         }
       } else {
-        params.near = near;
+        params.ll = lat + ',' + lng;
       }
-    } else {
-      params.ll = lat + ',' + lng;
     }
 
     logger.debug('search:lat: ' + lat);
@@ -480,14 +483,23 @@ module.exports = function(config) {
     logger.enter('suggestComplete');
     params = params || {};
 
-    logger.debug('explore:params: ' + util.inspect(params));
-
-    if(!lat || !lng) {
-      logger.error('Lat and Lng are both required parameters.');
-      callback(new Error('Venues.explore: lat and lng are both required.'));
+    logger.debug('getSuggestcompletion:params: ' + util.inspect(params));
+    
+    if (!query || query.length < 3) {
+      logger.error('Query is required and must be at least 3 characters long.');
+      callback(new Error('Venues.getSuggestcompletion: Query is required and must be at least 3 characters long.'));
       return;
     }
-    params.ll = lat + ',' + lng;
+    
+    if (!lat || !lng) {
+      if (!params.near) {
+        logger.error('Either lat and lng or near are required as parameters.');
+        callback(new Error('Venues.getSuggestcompletion: near must be specified as a parameter if lat and lng are not set.'));
+        return;
+      }
+    } else {      
+      params.ll = lat + ',' + lng;
+    }
 
     if(!query) {
       logger.error('Query is a required parameter.');

--- a/test/venues-test.js
+++ b/test/venues-test.js
@@ -262,6 +262,24 @@ var VenuesTest = function(config, accessToken) {
         }
       });
     },
+    
+    getSuggestcompletionWithNear : function() {
+      var test = 'Foursquare.Venues.getSuggestcompletion(null, null, \'foursqu\')';
+      Foursquare.Venues.getSuggestcompletion(null, null, 'Baking', { near: 'Chicago' }, accessToken, function (error, data) {
+        if(error) {
+          testUtil.reportError(logger, test, error.message);
+        }
+        else {
+          try {
+            testUtil.reportData(logger, test, util.inspect(data));
+            assert.ok(data.minivenues);
+            testUtil.reportOk(logger, test);
+          } catch (error) {
+            testUtil.reportError(logger, test, error);
+          }
+        }
+      });
+    },
 
     getTimeseries : function() {
       testUtil.reportError(
@@ -338,6 +356,25 @@ var VenuesTest = function(config, accessToken) {
           try {
             testUtil.reportData(logger, test, util.inspect(data));
             assert.ok(data.venues);
+            testUtil.reportOk(logger, test);
+          } catch (error) {
+            testUtil.reportError(logger, test, error);
+          }
+        }
+      });
+    },
+    
+    searchGlobal : function() {
+      var test = 'Foursquare.Venues.search(null, null)';
+      Foursquare.Venues.search(null, null, null, { intent: 'global', query: 'Baking', limit: 1 }, accessToken, function (error, data) {
+        if(error) {
+          testUtil.reportError(logger, test, error);
+        }
+        else {
+          try {
+            testUtil.reportData(logger, test, util.inspect(data));
+            assert.ok(data.venues);
+            assert.ok(data.venues.length === 1);
             testUtil.reportOk(logger, test);
           } catch (error) {
             testUtil.reportError(logger, test, error);


### PR DESCRIPTION
- Do not validate lat/long when using the global search intent (they will be ignored by the Foursquare API anyway).
- Suggested completion query is required and should be 3 or more characters long.
- Do not validate lat/long if "near" is provided as a parameter (Issue #24).