### PR TITLE
Update logic on failing to parse the result

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -175,7 +175,10 @@ module.exports = (
     try {
       json = JSON.parse(result);
     } catch (e) {
-      callback(status);
+      callback({
+        status,
+        error: e,
+      });
       return;
     }
 
@@ -183,7 +186,10 @@ module.exports = (
 
     if (!meta) {
       logger.error(`Response had no metadata: ${util.inspect(json)}`);
-      callback(new Error(`Response had no metadata: ${util.inspect(json)}`));
+      callback({
+        status,
+        error: new Error(`Response had no metadata: ${util.inspect(json)}`),
+      });
       return;
     }
 
@@ -191,14 +197,20 @@ module.exports = (
 
     if (!code) {
       logger.error(`Response had no code: ${util.inspect(json)}`);
-      callback(new Error(`Response had no code: ${util.inspect(json)}`));
+      callback({
+        status,
+        error: new Error(`Response had no code: ${util.inspect(json)}`),
+      });
       return;
     } else if (code !== 200) {
       logger.error(
         `JSON Response had unexpected code: '${code}: ${errorDetail}'`,
       );
 
-      callback(new Error(`${code}: ${errorDetail}`));
+      callback({
+        status,
+        error: new Error(`${code}: ${errorDetail}`),
+      });
       return;
     }
 
@@ -213,7 +225,10 @@ module.exports = (
 
       if (config.foursquare.warnings === 'ERROR') {
         logger.error(message);
-        callback(new Error(message));
+        callback({
+          status,
+          error: new Error(message),
+        });
         return;
       }
 

--- a/src/core.js
+++ b/src/core.js
@@ -175,7 +175,7 @@ module.exports = (
     try {
       json = JSON.parse(result);
     } catch (e) {
-      callback(e);
+      callback(status);
       return;
     }
 


### PR DESCRIPTION
  * Callback with the status instead of a JSON parse error

I was experiencing an issue where Foursquare was sending a status `400`, however the result was not parsable.  This resulted in my callback getting called with `"Unexpected end of JSON input"` instead of a `400`.   I experienced this issue with version `v0.3.2`, but it seems that this will still be an issue with what is currently in `v0.4.0`.